### PR TITLE
FOV calculation, swapped movement/rotation thumb sticks.

### DIFF
--- a/SpaceEngineersVR/Player/Controller.cs
+++ b/SpaceEngineersVR/Player/Controller.cs
@@ -8,6 +8,7 @@ using VRageMath;
 
 namespace SpaceEngineersVR.Player
 {
+    [Flags]
     public enum Button : ulong
     {
         System = 1ul << EVRButtonId.k_EButton_System,
@@ -68,13 +69,13 @@ namespace SpaceEngineersVR.Player
 
         public Vector2 GetAxis(Axis axis = Axis.Joystick)
         {
-            switch ((int)axis)
+            switch (axis)
             {
-                case 0: return new Vector2(CurrentState.rAxis0.x, CurrentState.rAxis0.y);
-                case 1: return new Vector2(CurrentState.rAxis1.x, CurrentState.rAxis1.y);
-                case 2: return new Vector2(CurrentState.rAxis2.x, CurrentState.rAxis2.y);
-                case 3: return new Vector2(CurrentState.rAxis3.x, CurrentState.rAxis3.y);
-                case 4: return new Vector2(CurrentState.rAxis4.x, CurrentState.rAxis4.y);
+                case Axis.Joystick: return new Vector2(CurrentState.rAxis0.x, CurrentState.rAxis0.y);
+                case Axis.Trigger: return new Vector2(CurrentState.rAxis1.x, CurrentState.rAxis1.y);
+                case Axis.Grip: return new Vector2(CurrentState.rAxis2.x, CurrentState.rAxis2.y);
+                case Axis.Axis3: return new Vector2(CurrentState.rAxis3.x, CurrentState.rAxis3.y);
+                case Axis.Axis4: return new Vector2(CurrentState.rAxis4.x, CurrentState.rAxis4.y);
             }
             return Vector2.Zero;
         }

--- a/SpaceEngineersVR/Player/Headset.cs
+++ b/SpaceEngineersVR/Player/Headset.cs
@@ -168,8 +168,11 @@ namespace SpaceEngineersVR.Player
             msg.ProjectionMatrix = cam.ProjectionMatrix;
             msg.ProjectionFarMatrix = cam.ProjectionMatrixFar;
 
-            msg.FOV = cam.FovWithZoom;
-            msg.FOVForSkybox = cam.FovWithZoom;
+            var matrix = OpenVR.System.GetProjectionMatrix(eye, cam.NearPlaneDistance, cam.FarPlaneDistance, EGraphicsAPIConvention.API_DirectX).ToMatrix();
+            float fov = MathHelper.Atan(1.0f / matrix.M22) * 2f;
+
+            msg.FOV = fov;
+            msg.FOVForSkybox = fov;
             msg.NearPlane = cam.NearPlaneDistance;
             msg.FarPlane = cam.FarPlaneDistance;
             msg.FarFarPlane = cam.FarFarPlaneDistance;
@@ -262,17 +265,16 @@ namespace SpaceEngineersVR.Player
 
             if (!character.EnabledThrusts) 
             {
-                if (RightHand.IsValid)
-                {
-                    var vec = RightHand.GetAxis(Axis.Joystick);
-                    move.X = vec.X;
-                    move.Z = -vec.Y;
-                }
-                move *= 10;
-
                 if (LeftHand.IsValid)
                 {
                     var vec = LeftHand.GetAxis(Axis.Joystick);
+                    move.X = vec.X;
+                    move.Z = -vec.Y;
+                }
+
+                if (RightHand.IsValid)
+                {
+                    var vec = RightHand.GetAxis(Axis.Joystick);
                     rotate.Y = vec.X * 10;
                 }
 
@@ -292,6 +294,10 @@ namespace SpaceEngineersVR.Player
                         //move += v;
                     }
 
+                    var vec = RightHand.GetAxis(Axis.Joystick);
+                    rotate.Y = vec.X * 10;
+                    rotate.X = -vec.Y * 10;
+
                     //Util.DrawDebugLine(character.GetHeadMatrix(true).Translation + character.GetHeadMatrix(true).Forward, RightHand.WorldPos.Down, 0, 0, 255);
                     //Util.DrawDebugLine(character.GetHeadMatrix(true).Translation + character.GetHeadMatrix(true).Forward, Vector3D.Normalize(Vector3D.Lerp(RightHand.WorldPos.Down, RightHand.WorldPos.Forward, .5)), 255, 0, 0);
                     //Util.DrawDebugLine(character.GetHeadMatrix(true).Translation + character.GetHeadMatrix(true).Forward, RightHand.WorldPos.Forward, 0, 255, 0);
@@ -305,19 +311,16 @@ namespace SpaceEngineersVR.Player
                         //move += v;
                     }
 
-                    var vec = LeftHand.GetAxis(Axis.Joystick);
-                    rotate.Y = vec.X * 10;
-                    rotate.X = -vec.Y * 10;
                 }
             }
 
-            if (RightHand.IsNewButtonDown(Button.A))
+            if (LeftHand.IsNewButtonDown(Button.A))
             {
                 //TODO: wrist GUI
                 character.SwitchThrusts();
             }
 
-            //character.MoveAndRotate(move, rotate, 0f);
+            character.MoveAndRotate(move, rotate, 0f);
         }
         #endregion
 


### PR DESCRIPTION
FOV calculation helps a bit with perspective, but there is still the issue of things appearing further apart in each eye the further away you are from them. I'm not totally sure the calculated FOV is correct, but it feels a lot better than before. The calculated FOV is ultimately used to calculate the number in the projection matrix from the same element as I read from OpenVR's projection matrix. So its basically just copying the value from OpenVR's matrix, maybe that is what we need to do to fix the other issues?
Movement on the left stick and rotation on the right, is how most games do it.