### PR TITLE
Fix camera lagging behind character/grid.

### DIFF
--- a/SpaceEngineersVR/Patches/FrameInjections.cs
+++ b/SpaceEngineersVR/Patches/FrameInjections.cs
@@ -55,6 +55,11 @@ namespace SpaceEngineersVR.Patches
             Common.Plugin.Harmony.Patch(AccessTools.Method("VRageRender.MyRender11:SetupCameraMatricesInternal"),
                 transpiler: new HarmonyMethod(typeof(FrameInjections), nameof(Transpiler_SetupCameraMatrices)));
 
+            Common.Plugin.Harmony.Patch(AccessTools.Method(typeof(Sandbox.Game.Gui.MyGuiScreenGamePlay), "Draw"),
+                transpiler: new HarmonyMethod(typeof(FrameInjections), nameof(Transpiler_RemoveCallsToControlCameraAndUpdate)));
+            Common.Plugin.Harmony.Patch(AccessTools.Method(typeof(Sandbox.Game.Gui.MyGuiScreenLoadInventory), "DrawScene"),
+                transpiler: new HarmonyMethod(typeof(FrameInjections), nameof(Transpiler_RemoveCallsToControlCameraAndUpdate)));
+
             Logger.Info("Applied harmony game injections for renderer.");
         }
 
@@ -144,9 +149,72 @@ namespace SpaceEngineersVR.Patches
                 ) {
                     //TODO: FIXME: Not moving lables/blocks that may have been added by other patches
                     code.RemoveRange(i, 4);
-                    i--;
+                    --i;
                 }
             }
+
+            return code;
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler_RemoveCallsToControlCameraAndUpdate(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> code = new List<CodeInstruction>(instructions);
+
+            MethodInfo getMySectorMainCamera = AccessTools.PropertyGetter(typeof(Sandbox.Game.World.MySector), "MainCamera");
+
+            {
+                MethodInfo getMySessionStatic = AccessTools.PropertyGetter(typeof(Sandbox.Game.World.MySession), "Static");
+                MethodInfo getMySessionCameraController = AccessTools.PropertyGetter(typeof(Sandbox.Game.World.MySession), "CameraController");
+                MethodInfo controlCamera = AccessTools.Method(typeof(VRage.Game.ModAPI.Interfaces.IMyCameraController), "ControlCamera");
+                for(int i = 0; i < code.Count - 3; ++i)
+                {
+                    if(
+                        code[i + 0].Calls(getMySessionStatic) &&
+                        code[i + 1].Calls(getMySessionCameraController) &&
+                        code[i + 2].Calls(getMySectorMainCamera) &&
+                        code[i + 3].Calls(controlCamera)
+                    ) {
+                        //TODO: FIXME: Not moving lables/blocks that may have been added by other patches
+                        code.RemoveRange(i, 4);
+                        --i;
+                    }
+                }
+            }
+
+            {
+                MethodInfo cameraUpdate = AccessTools.Method(typeof(VRage.Game.Utils.MyCamera), "Update");
+                for(int i = 0; i < code.Count - 2; ++i)
+                {
+                    if(
+                        code[i + 0].Calls(getMySectorMainCamera) &&
+                        code[i + 1].LoadsConstant() &&
+                        code[i + 2].Calls(cameraUpdate)
+                    ) {
+                        //TODO: FIXME: Not moving lables/blocks that may have been added by other patches
+                        code.RemoveRange(i, 3);
+                        --i;
+                    }
+                }
+            }
+
+            /*
+            Enabling this one seems to completely prevent the game from getting past the loading screen
+            Tried calling it from our rendering, didnt fix
+            {
+                MethodInfo uploadViewMatrixToRender = AccessTools.Method(typeof(VRage.Game.Utils.MyCamera), "UploadViewMatrixToRender");
+                for(int i = 0; i < code.Count - 1; ++i)
+                {
+                    if(
+                        code[i + 0].Calls(getMySectorMainCamera) &&
+                        code[i + 1].Calls(uploadViewMatrixToRender)
+                    ) {
+                        //TODO: FIXME: Not moving lables/blocks that may have been added by other patches
+                        code.RemoveRange(i, 2);
+                        --i;
+                    }
+                }
+            }
+            */
 
             return code;
         }

--- a/SpaceEngineersVR/Player/Headset.cs
+++ b/SpaceEngineersVR/Player/Headset.cs
@@ -31,7 +31,7 @@ namespace SpaceEngineersVR.Player
 {
     internal class Headset
     {
-        public MatrixD hmdAbsolute;
+        public MatrixD hmdAbsolute = Matrix.Identity;
 
         public bool IsHeadsetConnected => OpenVR.IsHmdPresent();
         public bool IsHeadsetAlreadyDisconnected = false;
@@ -102,6 +102,9 @@ namespace SpaceEngineersVR.Player
                 firstUpdate = false;
                 return true;
             }
+
+            MySession.Static.CameraController.ControlCamera(cam);
+            cam.Update(0f);
 
             //MyRender11.FullDrawScene(false);
             texture?.Release();


### PR DESCRIPTION
Still an issue where camera occasionally moves to some other position for a frame, trying to find the cause.
Also fixes invalid camera matrixes if HMD is not visible when starting game.

Before: https://i.gyazo.com/b3c228dcf89a219ae52cf0436f1ee760.gif
After: https://i.gyazo.com/27e2c4aa7fa9129a417130bc8d79b47e.gif