### PR TITLE
Reverted random seed fix (PR #17)

### DIFF
--- a/SpaceEngineersVR/Patches/FrameInjections.cs
+++ b/SpaceEngineersVR/Patches/FrameInjections.cs
@@ -18,9 +18,6 @@ namespace SpaceEngineersVR.Patches
         public static Func<double, double, double, double, MatrixD> GetPerspectiveMatrix;
         public static Func<float, float, float, Matrix> GetPerspectiveMatrixRhInfiniteComplementary;
         
-        public static bool FirstEye;
-        private static MyRandom.State randomState;
-
         static FrameInjections()
         {
             Type t = AccessTools.TypeByName("VRageRender.MyRender11");
@@ -29,8 +26,6 @@ namespace SpaceEngineersVR.Patches
 
             Common.Plugin.Harmony.Patch(AccessTools.Method(t, "DrawScene"), new HarmonyMethod(typeof(FrameInjections), nameof(Prefix_DrawScene)));
 
-            Common.Plugin.Harmony.Patch(AccessTools.Method(AccessTools.TypeByName("VRageRender.MyCommon"), "UpdateFrameConstants"), new HarmonyMethod(typeof(FrameInjections), nameof(UpdateFrameConstantsPrefix)));
-            
             Common.Plugin.Harmony.Patch(AccessTools.Constructor(
                 AccessTools.TypeByName("VRage.Ansel.MyAnselCamera"),
                 new Type[]
@@ -68,22 +63,6 @@ namespace SpaceEngineersVR.Patches
             return !DisablePresent;
         }
 
-        private static bool UpdateFrameConstantsPrefix(ref MyRandom ___m_random)
-        {
-            if (FirstEye)
-            {
-                // Save the random state on rendering the first eye
-                ___m_random.GetState(out randomState);
-            }
-            else
-            {
-                // Force the same random state on the second eye
-                ___m_random.SetState(ref randomState);
-            }
-
-            return true;
-        }
-        
         private static IEnumerable<CodeInstruction> Transpiler_ReplaceCreatePerspectiveFOV(IEnumerable<CodeInstruction> instructions)
         {
             //Replace calls to MatrixD.CreatePerspectiveFieldOfView with calls to GetPerspectiveFov

--- a/SpaceEngineersVR/Player/Headset.cs
+++ b/SpaceEngineersVR/Player/Headset.cs
@@ -118,9 +118,7 @@ namespace SpaceEngineersVR.Player
             headToWorld = Matrix.Invert(headToWorld.GetOrientation()) * Matrix.CreateTranslation(headToWorld.Translation) * originalWm;
 
             // Stereo rendering
-            FrameInjections.FirstEye = true;
             DrawEye(EVREye.Eye_Right, headToWorld, cam);
-            FrameInjections.FirstEye = false;
             DrawEye(EVREye.Eye_Left,  headToWorld, cam);
 
             // Restore original matrices to remove the flickering


### PR DESCRIPTION
It is stopping some particle effects from being animated, for example the smoke on the ground below atmospheric thrusters.

While the logic works as expected it has this unexpected side effect, which will need to be investigated before putting this back.